### PR TITLE
Update to support spaces in network share locations

### DIFF
--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -185,7 +185,7 @@ if [ "$INI__network__mount_address" != "" ]
 then
     #mount samba share, readonly
     log_progress_msg "Mounting Windows Network drive..." "$NAME"
-    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
+    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password "$INI__network__mount_address" /music/Network/
 #    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
 #add rsize=2048,wsize=4096,cache=strict because of usb (from raspyfi)
 fi


### PR DESCRIPTION
Adding quotes around $INI__network__mount_address so that network share locations that have spaces in the path are mounted correctly.